### PR TITLE
Spelling

### DIFF
--- a/faulting_multiplications/operation.c
+++ b/faulting_multiplications/operation.c
@@ -20,7 +20,7 @@ int undervolting_finished=0;
 uint64_t plane0_zero;
 uint64_t plane2_zero;
 
-typedef struct calcuation_info_t
+typedef struct calculation_info_t
 {
 	char max_or_fixed_op1;
 	char max_or_fixed_op2;

--- a/sgx-aes/Enclave/encl.cpp
+++ b/sgx-aes/Enclave/encl.cpp
@@ -258,7 +258,7 @@ uint64_t fault_it(int iterations)
 
 void enclave_calculation(int iterations, int64_t offset)
 {
-	// calculate the unvervolting values to send to the msr 
+	// calculate the undervolting values to send to the msr 
 	plane0_return = wrmsr_value(0, 0);
 	plane2_return = wrmsr_value(0, 2);
 	plane0_offset = wrmsr_value(offset, 0);

--- a/utils/set_freq.sh
+++ b/utils/set_freq.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ $# -ne 1 ] ; then
 	echo "Incorrect number of arguments" >&2
-	echo "Useage $0 <frequency>" >&2
+	echo "Usage $0 <frequency>" >&2
 	echo "Example $0 1.6GHz" >&2
     exit
 fi


### PR DESCRIPTION
generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`